### PR TITLE
Deploy Scripts and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,6 @@
 
 This repository holds the documentation for the [Rhombus][rhombus] project.
 
-The production deploy can be found at:
-http://docs.rhombus.network/.
-
-The staging deploy can be found at:
-https://lunchtime-labs.github.io/rhombus-api-docs
-
 This repository is a fork of the API Generator [Slate][slate]. It should be
 rebased off of the head of the upstream repository.
 
@@ -34,6 +28,9 @@ git pull upstream master --rebase
 
 ### Staging
 
+The staging deploy can be found at:
+https://lunchtime-labs.github.io/rhombus-api-docs
+
 Add the remote for staging:
 
 ```
@@ -46,7 +43,10 @@ Deploy to staging:
 ./deploy.sh -r staging
 ```
 
-### Staging
+### Production
+
+The production deploy can be found at:
+http://docs.rhombus.network/.
 
 Add the remote for production:
 

--- a/README.md
+++ b/README.md
@@ -7,8 +7,7 @@ rebased off of the head of the upstream repository.
 
 ## Getting Started
 
-For instructions on getting up and running, please refer to the README
-documentation for [Slate][slate].
+For instructions on getting up and running, please refer to the [Slate README][slate].
 
 ## Updating
 
@@ -26,9 +25,10 @@ git pull upstream master --rebase
 
 ## Deploying
 
+Code is deployed via GitHub Pages.
+
 ### Staging
 
-The staging deploy can be found at:
 https://lunchtime-labs.github.io/rhombus-api-docs
 
 Add the remote for staging:
@@ -45,7 +45,6 @@ Deploy to staging:
 
 ### Production
 
-The production deploy can be found at:
 http://docs.rhombus.network/.
 
 Add the remote for production:

--- a/README.md
+++ b/README.md
@@ -1,115 +1,64 @@
-<p align="center">
-  <img src="https://raw.githubusercontent.com/lord/img/master/logo-slate.png" alt="Slate: API Documentation Generator" width="226">
-  <br>
-  <a href="https://travis-ci.org/lord/slate"><img src="https://travis-ci.org/lord/slate.svg?branch=master" alt="Build Status"></a>
-</p>
+# Rhombus Documentation
 
-<p align="center">Slate helps you create beautiful, intelligent, responsive API documentation.</p>
+This repository holds the documentation for the [Rhombus][rhombus] project.
 
-<p align="center"><img src="https://raw.githubusercontent.com/lord/img/master/screenshot-slate.png" width=700 alt="Screenshot of Example Documentation created with Slate"></p>
+The production deploy can be found at:
+http://docs.rhombus.network/.
 
-<p align="center"><em>The example above was created with Slate. Check it out at <a href="https://lord.github.io/slate">lord.github.io/slate</a>.</em></p>
+The staging deploy can be found at:
+https://lunchtime-labs.github.io/rhombus-api-docs
 
-Features
-------------
+This repository is a fork of the API Generator [Slate][slate]. It should be
+rebased off of the head of the upstream repository.
 
-* **Clean, intuitive design** — With Slate, the description of your API is on the left side of your documentation, and all the code examples are on the right side. Inspired by [Stripe's](https://stripe.com/docs/api) and [PayPal's](https://developer.paypal.com/webapps/developer/docs/api/) API docs. Slate is responsive, so it looks great on tablets, phones, and even in print.
+## Getting Started
 
-* **Everything on a single page** — Gone are the days when your users had to search through a million pages to find what they wanted. Slate puts the entire documentation on a single page. We haven't sacrificed linkability, though. As you scroll, your browser's hash will update to the nearest header, so linking to a particular point in the documentation is still natural and easy.
+For instructions on getting up and running, please refer to the README
+documentation for [Slate][slate].
 
-* **Slate is just Markdown** — When you write docs with Slate, you're just writing Markdown, which makes it simple to edit and understand. Everything is written in Markdown — even the code samples are just Markdown code blocks.
+## Updating
 
-* **Write code samples in multiple languages** — If your API has bindings in multiple programming languages, you can easily put in tabs to switch between them. In your document, you'll distinguish different languages by specifying the language name at the top of each code block, just like with GitHub Flavored Markdown.
+Add the upstream as a git remote:
 
-* **Out-of-the-box syntax highlighting** for [over 100 languages](https://github.com/jneen/rouge/wiki/List-of-supported-languages-and-lexers), no configuration required.
-
-* **Automatic, smoothly scrolling table of contents** on the far left of the page. As you scroll, it displays your current position in the document. It's fast, too. We're using Slate at TripIt to build documentation for our new API, where our table of contents has over 180 entries. We've made sure that the performance remains excellent, even for larger documents.
-
-* **Let your users update your documentation for you** — By default, your Slate-generated documentation is hosted in a public GitHub repository. Not only does this mean you get free hosting for your docs with GitHub Pages, but it also makes it simple for other developers to make pull requests to your docs if they find typos or other problems. Of course, if you don't want to use GitHub, you're also welcome to host your docs elsewhere.
-
-* **RTL Support** Full right-to-left layout for RTL languages such as Arabic, Persian (Farsi), Hebrew etc.
-
-Getting started with Slate is super easy! Simply fork this repository and follow the instructions below. Or, if you'd like to check out what Slate is capable of, take a look at the [sample docs](http://lord.github.io/slate).
-
-Getting Started with Slate
-------------------------------
-
-### Prerequisites
-
-You're going to need:
-
- - **Linux or macOS** — Windows may work, but is unsupported.
- - **Ruby, version 2.3.1 or newer**
- - **Bundler** — If Ruby is already installed, but the `bundle` command doesn't work, just run `gem install bundler` in a terminal.
-
-### Getting Set Up
-
-1. Fork this repository on GitHub.
-2. Clone *your forked repository* (not our original one) to your hard drive with `git clone https://github.com/YOURUSERNAME/slate.git`
-3. `cd slate`
-4. Initialize and start Slate. You can either do this locally, or with Vagrant:
-
-```shell
-# either run this to run locally
-bundle install
-bundle exec middleman server
-
-# OR run this to run with vagrant
-vagrant up
+```
+git remote add upstream git@github.com:lord/slate.git
 ```
 
-You can now see the docs at http://localhost:4567. Whoa! That was fast!
+Then rebase off the head of the upstream master.
 
-Now that Slate is all set up on your machine, you'll probably want to learn more about [editing Slate markdown](https://github.com/lord/slate/wiki/Markdown-Syntax), or [how to publish your docs](https://github.com/lord/slate/wiki/Deploying-Slate).
+```
+git pull upstream master --rebase
+```
 
-If you'd prefer to use Docker, instructions are available [in the wiki](https://github.com/lord/slate/wiki/Docker).
+## Deploying
 
-### Note on JavaScript Runtime
+### Staging
 
-For those who don't have JavaScript runtime or are experiencing JavaScript runtime issues with ExecJS, it is recommended to add the [rubyracer gem](https://github.com/cowboyd/therubyracer) to your gemfile and run `bundle` again.
+Add the remote for staging:
 
-Companies Using Slate
----------------------------------
+```
+git remote add staging git@github.com:lunchtime-labs/rhombus-api-docs.git
+```
 
-* [NASA](https://api.nasa.gov)
-* [Sony](http://developers.cimediacloud.com)
-* [Best Buy](https://bestbuyapis.github.io/api-documentation/)
-* [Travis-CI](https://docs.travis-ci.com/api/)
-* [Greenhouse](https://developers.greenhouse.io/harvest.html)
-* [Woocommerce](http://woocommerce.github.io/woocommerce-rest-api-docs/)
-* [Dwolla](https://docs.dwolla.com/)
-* [Clearbit](https://clearbit.com/docs)
-* [Coinbase](https://developers.coinbase.com/api)
-* [Parrot Drones](http://developer.parrot.com/docs/bebop/)
-* [Scale](https://docs.scaleapi.com/)
+Deploy to staging:
 
-You can view more in [the list on the wiki](https://github.com/lord/slate/wiki/Slate-in-the-Wild).
+```
+./deploy.sh -r staging
+```
 
-Questions? Need Help? Found a bug?
---------------------
+### Staging
 
-If you've got questions about setup, deploying, special feature implementation in your fork, or just want to chat with the developer, please feel free to [start a thread in our Spectrum community](https://spectrum.chat/slate)!
+Add the remote for production:
 
-Found a bug with upstream Slate? Go ahead and [submit an issue](https://github.com/lord/slate/issues). And, of course, feel free to submit pull requests with bug fixes or changes to the `dev` branch.
+```
+git remote add production git@github.com:RhombusNetwork/rhombus-docs.git
+```
 
-Contributors
---------------------
+Deploy to production:
 
-Slate was built by [Robert Lord](https://lord.io) while interning at [TripIt](https://www.tripit.com/).
+```
+./deploy.sh -r production
+```
 
-Thanks to the following people who have submitted major pull requests:
-
-- [@chrissrogers](https://github.com/chrissrogers)
-- [@bootstraponline](https://github.com/bootstraponline)
-- [@realityking](https://github.com/realityking)
-- [@cvkef](https://github.com/cvkef)
-
-Also, thanks to [Sauce Labs](http://saucelabs.com) for sponsoring the development of the responsive styles.
-
-Special Thanks
---------------------
-- [Middleman](https://github.com/middleman/middleman)
-- [jquery.tocify.js](https://github.com/gfranko/jquery.tocify.js)
-- [middleman-syntax](https://github.com/middleman/middleman-syntax)
-- [middleman-gh-pages](https://github.com/edgecase/middleman-gh-pages)
-- [Font Awesome](http://fortawesome.github.io/Font-Awesome/)
+[rhombus]: https://rhombus.network
+[slate]: https://github.com/lord/slate

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -o errexit #abort if any command fails
 me=$(basename "$0")
+default_remote="staging"
 
 help_message="\
 Usage: $me [-c FILE] [<options>]
@@ -17,6 +18,8 @@ Options:
                            commit's message.
       --source-only        Only build but not push
       --push-only          Only push but not build
+  -r, --remote             Specify the 'git remote' repository to push to.
+                           Defaults to '$default_remote'
 "
 
 
@@ -49,6 +52,9 @@ parse_args() {
     elif [[ $1 = "-n" || $1 = "--no-hash" ]]; then
       GIT_DEPLOY_APPEND_HASH=false
       shift
+    elif [[ ( $1 = "-r" || $1 = "--remote" ) && -n $2 ]]; then
+      remote=$2
+      shift 2
     else
       break
     fi
@@ -66,7 +72,7 @@ parse_args() {
   default_email=${GIT_DEPLOY_EMAIL:-}
 
   #repository to deploy to. must be readable and writable.
-  repo=origin
+  repo=${remote:-$default_remote}
 
   #append commit hash to the end of message by default
   append_hash=${GIT_DEPLOY_APPEND_HASH:-true}


### PR DESCRIPTION
This updates the deploy scripts so that you can deploy to staging or production.

It also updates the README so that it is clear how to use these scripts.

``` shell
rhombus-docs lp-deploy-scripts % ./deploy.sh -r staging
   identical  build/stylesheets/print.css
   identical  build/stylesheets/screen.css
   identical  build/fonts/radomir-tinkov-gilroy-bold-webfont.woff
   identical  build/images/navbar.png
   identical  build/fonts/radomir-tinkov-gilroy-light-webfont.woff
   identical  build/fonts/radomir-tinkov-gilroy-light-webfont.woff2
   identical  build/fonts/slate.woff
   identical  build/fonts/slate.woff2
   identical  build/fonts/radomir-tinkov-gilroy-bold-webfont.woff2
   identical  build/fonts/slate.eot
   identical  build/fonts/slate.ttf
   identical  build/images/logo.png
   identical  build/fonts/slate.svg
   identical  build/javascripts/all_nosearch.js
   identical  build/javascripts/all.js
   identical  build/index.html
   identical  build/style_guide.html
Project built successfully.
21144cd0ba2def01a6f6554cf8fb2a2a2c9e680f        refs/heads/gh-pages
No changes to files in build. Skipping commit.
```
